### PR TITLE
Steps to ensure that libao is in the PATH for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Simply compile and install `node-libao` using `npm`:
 $ npm install libao
 ```
 
+Note: you will need to have `libao` included in your path before trying to install `node-libao`
+
+OSX:
+``` bash
+$ brew install libao
+```
+
 A few examples
 --------------
 


### PR DESCRIPTION
Just a simple README update to ensure that users know to install `libao` before attempting to install via npm.